### PR TITLE
Create ability to add new units to problem before calling NumberWithU…

### DIFF
--- a/macros/parserFormulaWithUnits.pl
+++ b/macros/parserFormulaWithUnits.pl
@@ -73,13 +73,13 @@ loadMacros('MathObjects.pl');
  #  Now uses the version in Parser::Legacy::NumberWithUnits
  #  to avoid duplication of common code.
  #
+our %fundamental_units = %Units::fundamental_units;
+our %known_units = %Units::known_units;
 
 sub _parserFormulaWithUnits_init {
     # We make copies of these hashes here because these copies will be unique to  # the problem.  The hashes in Units are shared between problems.  We pass
   # the hashes for these local copies to the NumberWithUnits package to use
   # for all of its stuff.  
-  my %fundamental_units = %Units::fundamental_units;
-  my %known_units = %Units::known_units;
 
   
   Parser::Legacy::ObjectWithUnits::initializeUnits(\%fundamental_units,\%known_units);
@@ -87,4 +87,10 @@ sub _parserFormulaWithUnits_init {
   main::PG_restricted_eval('sub FormulaWithUnits {Parser::Legacy::FormulaWithUnits->new(@_)}');
 }
 
+sub parserFormulaWithUnits::fundamental_units {
+	return \%fundamental_units;
+}
+sub parserFormulaWithUnits::known_units {
+	return \%known_units;
+}
 1;

--- a/macros/parserNumberWithUnits.pl
+++ b/macros/parserNumberWithUnits.pl
@@ -67,17 +67,30 @@ attempt to display a grammerically correct result.
 
 loadMacros('MathObjects.pl');
 
+our %fundamental_units = %Units::fundamental_units;
+our %known_units = %Units::known_units;
+
 sub _parserNumberWithUnits_init {
   # We make copies of these hashes here because these copies will be unique to  # the problem.  The hashes in Units are shared between problems.  We pass
   # the hashes for these local copies to the NumberWithUnits package to use
   # for all of its stuff.  
-  my %fundamental_units = %Units::fundamental_units;
-  my %known_units = %Units::known_units;
 
   
   Parser::Legacy::ObjectWithUnits::initializeUnits(\%fundamental_units,\%known_units);
+  # main::PG_restricted_eval('sub NumberWithUnits {Parser::Legacy::NumberWithUnits->new(@_)}');
   
-  main::PG_restricted_eval('sub NumberWithUnits {Parser::Legacy::NumberWithUnits->new(@_)}');
+}
+sub NumberWithUnits {Parser::Legacy::NumberWithUnits->new(@_)};
+sub parserNumberWithUnits::fundamental_units {
+	return \%fundamental_units;
+}
+sub parserNumberWithUnits::known_units {
+	return \%known_units;
+}
+sub parserNumberWithUnits::add_unit {
+    my $newUnit = shift;
+	my $Units= Parser::Legacy::ObjectWithUnits::add_unit($newUnit->{name}, $newUnit->{conversion});
+    return %$Units;
 }
 
 1;


### PR DESCRIPTION
1. the accessor's are simply so that we can grab the current value of %known_units and %fundamental_units as stored in parserNumberWithUnits.pl.  %Units::known_units didn't 
   update as items were added. 
2. The add_unit subroutine is so that you can add the units to the files environment directly without
   having to create an answer evaluator.  This seemed more natural to me although there is no reason
   to remove the automatic adding of a unit to the environment when creating an evaluator.

This is the test code I put in problems to determine which new units were defined:

```
@check_these_units = qw(apple apples Spoon bear rabbit foobear);
DEBUG_MESSAGE("checking for ", join(' ', @check_these_units), $BR);
$string='';
$fund = parserNumberWithUnits::fundamental_units();
$known = parserNumberWithUnits::known_units;
foreach my $key (@check_these_units) {
  $string .="$key is a fundamental unit$BR" if exists($fund->{$key});
  $string .="$key is a known unit$BR" if exists($known->{$key});
  $string.= "$key is an undefined unit $BR" unless exists($known->{$key});
}
DEBUG_MESSAGE( $string);


```

Change the formula file in the same way.  
